### PR TITLE
pc - fix to deprecation of setting NODE_ENV=src in .env 

### DIFF
--- a/javascript/jsconfig.json
+++ b/javascript/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
In this PR, we address the fact that it is _deprecated_ to put this text into `javascript/.env` in order to allow `import` via absolute path

```
NODE_ENV=src
```

Deleting that file without replacing it with another approach will result in an error where the application fails to load with an error in `javascript/src/index.js` on the line that tries to do `import App from "main/App";`

So, intstead, per Justin Vo's suggestion, replace with adding options into `jsconfig.json` as follows:

```
{
  "compilerOptions": {
    "baseUrl": "src"
  },
  "include": [
    "src"
  ]
}
```