### PR TITLE
pc - add hook to RoleController /api/myRole to update users table

### DIFF
--- a/src/main/java/edu/ucsb/changeme/advice/AuthControllerAdvice.java
+++ b/src/main/java/edu/ucsb/changeme/advice/AuthControllerAdvice.java
@@ -55,8 +55,7 @@ public class AuthControllerAdvice {
     return service.isMember(getJWT(authorization));
   }
 
-
-  private AppUser updateAppUsers(String authorization) {
+  public AppUser updateAppUsers(String authorization) {
     DecodedJWT jwt = getJWT(authorization);
     Map<String, Object> customClaims = jwt.getClaim(namespace).asMap();
     String email = (String) customClaims.get("email");

--- a/src/main/java/edu/ucsb/changeme/controllers/RoleController.java
+++ b/src/main/java/edu/ucsb/changeme/controllers/RoleController.java
@@ -95,6 +95,7 @@ public class RoleController {
   @GetMapping("/myRole")
   public ResponseEntity<String> myRole(@RequestHeader("Authorization") String authorization)
       throws JsonProcessingException {
+    authControllerAdvice.updateAppUsers(authorization);
     String role = authControllerAdvice.getRole(authorization);
     Map<String, String> response = new HashMap<>();
     response.put("role", role);


### PR DESCRIPTION
Closes #3 

## Summary


## User Story

As an admin, I can visit the admin panel and promote/demote users so that I can maintain a list of current admins.

## Similar issues

* Identical to this issue https://github.com/ucsb-cs156-f20/demo-spring-react-todo-app/pull/49  (from a different application)
*  You can follow this pull request as a road map: https://github.com/ucsb-cs156-f20/demo-spring-react-todo-app/pull/49

## Acceptance Criteria

- [x] In the list of users, permanent admins are identified as such, and cannot be demoted
- [x] On the user list, there is a way to promote users to Admin status
- [x] On the admin list, there is a way to demote users to non-admin status
- [x] Changes made in the admin panel affect the role of the user's role being changed.

# How it was implemented

All of this code was already in the code base; but it wasn't working.

It appears that the bug was that there was no code to add users into the users table when they login in.

It was difficult to find a place to do this in the app, but I finally settled on the RoleController, in the `/api/myRole` endpoint.
 
This also involved making the `updateAppUsers` method in `authControllerAdvice` public instead of private.

## Testing

It appears that the tests for the backend code may already be in place
