### PR TITLE
Pc/bt Add ESLint GitHub Action and address all current style violations

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,26 @@
+name: ESLint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    env:
+      NODE_PATH: src/
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: ./javascript
+      - run: npx eslint --max-warnings 0 .
+        working-directory: ./javascript

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This repo is intended to be starter code for apps that have a
 
 * The npm package `prettier` is used to implement a pre-commit hook that formats JavaScript code.  See: [docs/prettier.md](./docs/prettier.md) for more information.
 
+* The npm package `eslint` is used to implement linting for the code under `javascript`.  See [docs/eslint.md](./docs/eslint.md) for more information 
+
 ## Getting Started
 
 To get started with this application, you'll need to be able to

--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -1,0 +1,30 @@
+# Using `eslint`
+
+The GitHub Actions for this repo include running the `eslint` utility on the contents of the `javascript/` directory
+to look for style violations in JavaScript code.    
+
+If a Pull Request fails due to style violations, in many cases you can use `eslint` to fix these by running these commands:
+
+```
+cd javascript       # if not already in the javascript directory
+npx eslint --fix src
+git status            # to see which files were changed
+git diff                 # to see exactly what changed
+```
+
+Then do a commit to commit the fixes.
+
+# Rules that aren't fixed automatically
+
+There are a few common violations that
+have to be fixed manually:
+
+* Removing unused imports
+* Removing unused variables and arguments (or you can mark them to be ignored by prefixing them with `_` e.g. `_result` instead of `result`).
+
+# Configuring the Rules
+
+The rules for eslint are configured
+in the file `javascript/.eslintrc.json`
+
+See the [ESLint documentation](https://eslint.org/docs/user-guide/configuring/configuration-files#using-configuration-files) for more information the syntax for configuring these rules.

--- a/javascript/.eslintignore
+++ b/javascript/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -13,5 +13,17 @@
         "jest": true
       }
     }
-  ]
+  ],
+  "rules": {
+    "no-unused-vars": [
+      "error", 
+      { 
+        "vars": "all", 
+        "varsIgnorePattern": "^_",
+        "args": "all", 
+        "argsIgnorePattern": "^_",
+        "ignoreRestSiblings": true
+      }
+    ]
+  } 
 }

--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "root": true,
+  "extends": ["react-app"],
+  "env": {
+    "browser": true
+  },
+  "overrides": [
+    {
+      "files": ["src/test/**/*.js"],
+      "env": {
+        "browser": false,
+        "node": true,
+        "jest": true
+      }
+    }
+  ]
+}

--- a/javascript/src/main/App.js
+++ b/javascript/src/main/App.js
@@ -15,14 +15,10 @@ import useSWR from "swr";
 import { fetchWithToken } from "main/utils/fetch";
 import AuthorizedRoute from "main/components/Nav/AuthorizedRoute";
 
-
 function App() {
   const { isLoading, getAccessTokenSilently: getToken } = useAuth0();
-  const { data: roleInfo } = useSWR(
-    ["/api/myRole", getToken],
-    fetchWithToken
-  );
-  const isAdmin = roleInfo && roleInfo.role.toLowerCase() === "admin";
+  const { data: roleInfo } = useSWR(["/api/myRole", getToken], fetchWithToken);
+  const _isAdmin = roleInfo && roleInfo.role.toLowerCase() === "admin";
 
   if (isLoading) {
     return <Loading />;
@@ -35,7 +31,11 @@ function App() {
         <Switch>
           <Route path="/" exact component={Home} />
           <PrivateRoute path="/profile" component={Profile} />
-          <AuthorizedRoute path="/admin" component={Admin} authorizedRoles={["admin"]}/>
+          <AuthorizedRoute
+            path="/admin"
+            component={Admin}
+            authorizedRoles={["admin"]}
+          />
           <Route path="/about" component={About} />
         </Switch>
       </Container>

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -1,20 +1,18 @@
 import React from "react";
 import { Jumbotron } from "react-bootstrap";
-import {useAuth0} from "@auth0/auth0-react";
-import { Redirect } from "react-router-dom";
+import { useAuth0 } from "@auth0/auth0-react";
 
 const Home = () => {
-    const { isAuthenticated } = useAuth0();
+  const { _isAuthenticated } = useAuth0();
 
-    return (
-            <Jumbotron>
-                <div className="text-left">
-                    <h5>Welcome to the (Changeme To App Name) App!</h5>
-                    <p>This is where your home page content goes
-                    </p>
-                </div>
-            </Jumbotron>
-    );
+  return (
+    <Jumbotron>
+      <div className="text-left">
+        <h5>Welcome to the (Changeme To App Name) App!</h5>
+        <p>This is where your home page content goes</p>
+      </div>
+    </Jumbotron>
+  );
 };
 
 export default Home;

--- a/javascript/src/test/App.test.js
+++ b/javascript/src/test/App.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import App from "main/App";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";

--- a/javascript/src/test/App.test.js
+++ b/javascript/src/test/App.test.js
@@ -4,8 +4,8 @@ import App from "main/App";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
-jest.mock("@auth0/auth0-react");
 import useSWR from "swr";
+jest.mock("@auth0/auth0-react");
 jest.mock("swr");
 
 describe("App tests", () => {
@@ -19,8 +19,8 @@ describe("App tests", () => {
     });
     useSWR.mockReturnValue({
       data: {
-        role: "guest"
-      }
+        role: "guest",
+      },
     });
   });
 
@@ -45,12 +45,12 @@ describe("App tests", () => {
     expect(loading).toBeInTheDocument();
   });
 
-    // Unfortunately, there is no way to verify that the admin route is available or not. As a result, this test verifies another side-effect of being an admin.
+  // Unfortunately, there is no way to verify that the admin route is available or not. As a result, this test verifies another side-effect of being an admin.
   test("renders admin route when user is admin", async () => {
     useSWR.mockReturnValue({
       data: {
-        role: "admin"
-      }
+        role: "admin",
+      },
     });
     const history = createMemoryHistory();
     const { getByText } = render(

--- a/javascript/src/test/components/Nav/AppNavbar.test.js
+++ b/javascript/src/test/components/Nav/AppNavbar.test.js
@@ -2,9 +2,9 @@ import React from "react";
 import { render } from "@testing-library/react";
 import AppNavbar from "main/components/Nav/AppNavbar";
 import { useAuth0 } from "@auth0/auth0-react";
-jest.mock("@auth0/auth0-react");
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
+jest.mock("@auth0/auth0-react");
 
 describe("AppNavbar tests", () => {
   beforeEach(() => {
@@ -31,7 +31,6 @@ describe("AppNavbar tests", () => {
         <AppNavbar />
       </Router>
     );
-
 
     const userInfoLink = getByText(/Profile/);
     expect(userInfoLink.href).toMatch("/profile");

--- a/javascript/src/test/components/Nav/AuthorizedRoute.test.js
+++ b/javascript/src/test/components/Nav/AuthorizedRoute.test.js
@@ -4,14 +4,14 @@ import AuthorizedRoute from "main/components/Nav/AuthorizedRoute";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
-jest.mock("@auth0/auth0-react");
 import useSWR from "swr";
+jest.mock("@auth0/auth0-react");
 jest.mock("swr");
 
 describe("Authorized Route tests", () => {
   const component = () => {
-    return (<div>Hello</div>);
-  }
+    return <div>Hello</div>;
+  };
 
   beforeEach(() => {
     useAuth0.mockReturnValue({
@@ -20,34 +20,37 @@ describe("Authorized Route tests", () => {
     });
     useSWR.mockReturnValue({
       data: {
-        role: "guest"
-      }
+        role: "guest",
+      },
     });
   });
 
   test("if data not yet retrieved, render loading", () => {
     useAuth0.mockReturnValue({
-      isLoading: true
+      isLoading: true,
     });
-    const {getByAltText} = render(
-    <Router history={createMemoryHistory()}>
-      <AuthorizedRoute component={component} authorizedRoles={[]}/>
-    </Router>);
+    const { getByAltText } = render(
+      <Router history={createMemoryHistory()}>
+        <AuthorizedRoute component={component} authorizedRoles={[]} />
+      </Router>
+    );
     expect(getByAltText("Loading")).toBeInTheDocument();
   });
   test("if role doesn't match authorized role, component should not render", () => {
-    const {queryByText} = render(
-    <Router history={createMemoryHistory()}>
-      <AuthorizedRoute component={component} authorizedRoles={["admin"]} />
-    </Router>);
+    const { queryByText } = render(
+      <Router history={createMemoryHistory()}>
+        <AuthorizedRoute component={component} authorizedRoles={["admin"]} />
+      </Router>
+    );
     expect(queryByText("Hello")).toBe(null);
   });
 
   test("if condition is true, component should", () => {
-    const {getByText} = render(
-    <Router history={createMemoryHistory()}>
-      <AuthorizedRoute component={component} authorizedRoles={["guest"]} />
-    </Router>);
+    const { getByText } = render(
+      <Router history={createMemoryHistory()}>
+        <AuthorizedRoute component={component} authorizedRoles={["guest"]} />
+      </Router>
+    );
     expect(getByText("Hello")).toBeInTheDocument();
   });
 });

--- a/javascript/src/test/components/Nav/LogoutButton.test.js
+++ b/javascript/src/test/components/Nav/LogoutButton.test.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { useAuth0 } from "@auth0/auth0-react";
-jest.mock("@auth0/auth0-react");
 import LogoutButton from "main/components/Nav/LogoutButton";
 import userEvent from "@testing-library/user-event";
+jest.mock("@auth0/auth0-react");
 
 describe("logout button tests", () => {
   beforeEach(() => {

--- a/javascript/src/test/pages/Admin/Admin.test.js
+++ b/javascript/src/test/pages/Admin/Admin.test.js
@@ -47,7 +47,7 @@ describe("Admin tests", () => {
     useAuth0.mockReturnValue({
       getAccessTokenSilently: jest.fn(),
     });
-    useSWR.mockImplementation(([endpoint, getToken], fetch) => {
+    useSWR.mockImplementation(([endpoint, _getToken], _fetch) => {
       if (endpoint === "/api/users")
         return {
           data: users,
@@ -65,7 +65,7 @@ describe("Admin tests", () => {
   });
 
   test("renders when no admins exist", () => {
-    useSWR.mockImplementation(([endpoint, getToken], fetch) => {
+    useSWR.mockImplementation(([endpoint, _getToken], _fetch) => {
       if (endpoint === "/api/users")
         return {
           data: users,

--- a/javascript/src/test/pages/Admin/Admin.test.js
+++ b/javascript/src/test/pages/Admin/Admin.test.js
@@ -3,10 +3,10 @@ import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Admin from "main/pages/Admin/Admin";
 import { useAuth0 } from "@auth0/auth0-react";
-jest.mock("@auth0/auth0-react");
 import useSWR from "swr";
-jest.mock("swr");
 import { fetchWithToken } from "main/utils/fetch";
+jest.mock("@auth0/auth0-react");
+jest.mock("swr");
 jest.mock("main/utils/fetch");
 
 describe("Admin tests", () => {
@@ -14,12 +14,12 @@ describe("Admin tests", () => {
     {
       id: 2,
       email: "cgaucho@ucsb.edu",
-      isPermanentAdmin: true
+      isPermanentAdmin: true,
     },
     {
       id: 3,
       email: "ldelplaya@usa.gov",
-      isPermanentAdmin: false
+      isPermanentAdmin: false,
     },
   ];
   const users = [
@@ -27,19 +27,19 @@ describe("Admin tests", () => {
       id: 1,
       email: "test@example.com",
       firstName: "Test",
-      lastName: "Person"
+      lastName: "Person",
     },
     {
       id: 2,
       email: "cgaucho@ucsb.edu",
       firstName: "Chris",
-      lastName: "Gaucho"
+      lastName: "Gaucho",
     },
     {
       id: 3,
       email: "ldelplaya@usa.gov",
       firstName: "Laura",
-      lastName: "Del Playa"
+      lastName: "Del Playa",
     },
   ];
   const mutateSpy = jest.fn();
@@ -82,7 +82,7 @@ describe("Admin tests", () => {
 
   test("renders all users in table", () => {
     const { getByText } = render(<Admin />);
-    users.forEach(user => {
+    users.forEach((user) => {
       expect(getByText(String(user.id))).toBeInTheDocument();
       expect(getByText(user.email)).toBeInTheDocument();
       expect(getByText(user.firstName)).toBeInTheDocument();
@@ -92,7 +92,7 @@ describe("Admin tests", () => {
 
   test("renders all roles in table", () => {
     const { getByText, getAllByText } = render(<Admin />);
-    users.forEach(user => {
+    users.forEach((user) => {
       expect(getByText(String(user.id))).toBeInTheDocument();
       expect(getByText(user.email)).toBeInTheDocument();
       expect(getByText(user.firstName)).toBeInTheDocument();
@@ -106,7 +106,7 @@ describe("Admin tests", () => {
     fetchWithToken.mockReturnValueOnce({
       id: 12,
       email: users[0].email,
-      isPermanentAdmin: false
+      isPermanentAdmin: false,
     });
     const { getByText } = render(<Admin />);
     userEvent.click(getByText("Promote"));

--- a/javascript/src/test/pages/Profile/Profile.test.js
+++ b/javascript/src/test/pages/Profile/Profile.test.js
@@ -2,8 +2,8 @@ import React from "react";
 import { render } from "@testing-library/react";
 import Profile from "main/pages/Profile/Profile";
 import { useAuth0 } from "@auth0/auth0-react";
-jest.mock("@auth0/auth0-react");
 import useSWR from "swr";
+jest.mock("@auth0/auth0-react");
 jest.mock("swr");
 
 describe("Profile tests", () => {
@@ -17,9 +17,9 @@ describe("Profile tests", () => {
     });
     useSWR.mockReturnValue({
       data: {
-        role : "Admin"
-      }
-    })
+        role: "Admin",
+      },
+    });
   });
   test("renders without crashing", () => {
     render(<Profile />);
@@ -27,12 +27,12 @@ describe("Profile tests", () => {
 
   test("renders loading when role hasn't been retrieved", () => {
     useSWR.mockReturnValue({});
-    const { getByText } =render(<Profile />);
+    const { getByText } = render(<Profile />);
     expect(getByText("Loading role...")).toBeInTheDocument();
   });
 
   test("renders role correctly", () => {
-    const { getByText } =render(<Profile />);
+    const { getByText } = render(<Profile />);
     expect(getByText("Admin")).toBeInTheDocument();
   });
 });

--- a/javascript/src/test/utils/fetch.test.js
+++ b/javascript/src/test/utils/fetch.test.js
@@ -27,7 +27,7 @@ describe("fetch tests", () => {
       status: 200,
       json: jsonSpy,
     });
-    const response = await fetchWithToken("/api/test", getToken, {
+    const _response = await fetchWithToken("/api/test", getToken, {
       noJSON: true,
     });
     expect(jsonSpy).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
This PR supercedes PR #9 (it's built off that branch).

In this PR, we:
* make  GitHub Actions run ESLint as a CI workflow (work by @btk5h )
* fix the style violations found after running these commands on the branch `btESLint` (work by @pconrad )
* configure the rules to allow unused args and vars that start with `_`  (work by @pconrad )
* update the documentation about ESLint (work by @pconrad )

You can look at #9 to see an example of the kinds of annotations of style violations that this integration provides.   Each of the style violations reported in the PR #9 is one that is now fixed in this PR.