### PR TITLE
pc - add github workflow to publish storybook

### DIFF
--- a/.github/workflows/publish-storybook-to-github-pages.yml
+++ b/.github/workflows/publish-storybook-to-github-pages.yml
@@ -1,0 +1,28 @@
+# https://dev.to/kouts/deploy-storybook-to-github-pages-3bij
+
+name: Build and Deploy
+on: 
+  push:
+    branches:
+      - main
+    paths: ["stories/**", "src/components/**"] # Trigger the action only when files change in the folders defined here
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - name: Install and Build 🔧
+        run: | # Install npm packages and build the Storybook files
+          npm install
+          npm run build-storybook
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: main # The branch the action should deploy to.
+          FOLDER: docs-build # The folder that the build-storybook script generates files.
+          CLEAN: true # Automatically remove deleted files from the deploy branch
+          TARGET_FOLDER: docs/storybook # The folder that we serve our Storybook files from

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Don't check in a built storybook
 
 javascript/storybook-static
+javascript/docs-build
 
 # We don't want node_modules, package.json or package-lock.json at top level
 # Only under javascript/ directory

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -24,7 +24,7 @@
     "coverage": "react-scripts test --env=jsdom-fourteen --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -o docs-build"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
In this PR, we add a GitHub workflow to publish the storybook using GitHub pages.

We use the process described here: 
* https://dev.to/kouts/deploy-storybook-to-github-pages-3bij

This requires adding a token to the repository secrets that has the ability to push to GitHub