### PR TITLE
pc - example of TaskScheduler tasks

### DIFF
--- a/src/main/java/edu/ucsb/changeme/taskscheduler/ThreadPoolTaskSchedulerConfig.java
+++ b/src/main/java/edu/ucsb/changeme/taskscheduler/ThreadPoolTaskSchedulerConfig.java
@@ -1,0 +1,44 @@
+package edu.ucsb.changeme.taskscheduler;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.scheduling.support.PeriodicTrigger;
+
+// https://www.baeldung.com/spring-task-scheduler
+// https://github.com/eugenp/tutorials/tree/master/spring-scheduling
+
+@Configuration
+@ComponentScan(basePackages = "edu.ucsb.changeme.taskscheduler", basePackageClasses = { ThreadPoolTaskSchedulerExamples.class })
+public class ThreadPoolTaskSchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(5);
+        threadPoolTaskScheduler.setThreadNamePrefix("ThreadPoolTaskScheduler");
+        return threadPoolTaskScheduler;
+    }
+
+    @Bean
+    public CronTrigger cronTrigger() {
+        return new CronTrigger("10 * * * * ?");
+    }
+
+    @Bean
+    public PeriodicTrigger periodicTrigger() {
+        return new PeriodicTrigger(11, TimeUnit.SECONDS);
+    }
+
+    @Bean
+    public PeriodicTrigger periodicFixedDelayTrigger() {
+        PeriodicTrigger periodicTrigger = new PeriodicTrigger(2000, TimeUnit.MICROSECONDS);
+        periodicTrigger.setFixedRate(true);
+        periodicTrigger.setInitialDelay(1000);
+        return periodicTrigger;
+    }
+}

--- a/src/main/java/edu/ucsb/changeme/taskscheduler/ThreadPoolTaskSchedulerExamples.java
+++ b/src/main/java/edu/ucsb/changeme/taskscheduler/ThreadPoolTaskSchedulerExamples.java
@@ -1,0 +1,48 @@
+package edu.ucsb.changeme.taskscheduler;
+
+import java.util.Date;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.scheduling.support.PeriodicTrigger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThreadPoolTaskSchedulerExamples {
+    @Autowired
+    private ThreadPoolTaskScheduler taskScheduler;
+
+    @Autowired
+    private CronTrigger cronTrigger;
+
+    @Autowired
+    private PeriodicTrigger periodicTrigger;
+
+    @PostConstruct
+    public void scheduleRunnableWithCronTrigger() {
+        // taskScheduler.schedule(new RunnableTask("Current Date"), new Date());
+        taskScheduler.scheduleWithFixedDelay(new RunnableTask("Fixed 5 second Delay"), 5000);
+        // taskScheduler.scheduleWithFixedDelay(new RunnableTask("Current Date Fixed 1 second Delay"), new Date(), 1000);
+        taskScheduler.scheduleAtFixedRate(new RunnableTask("Fixed Rate of 7 seconds"), new Date(), 7000);
+        taskScheduler.scheduleAtFixedRate(new RunnableTask("Fixed Rate of 2 seconds"), 2000);
+        // taskScheduler.schedule(new RunnableTask("Cron Trigger"), cronTrigger);
+        // taskScheduler.schedule(new RunnableTask("Periodic Trigger"), periodicTrigger);
+    }
+
+    class RunnableTask implements Runnable {
+
+        private String message;
+
+        public RunnableTask(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void run() {
+            System.out.println("Runnable Task with " + message + " on thread " + Thread.currentThread().getName());
+        }
+    }
+}


### PR DESCRIPTION
This draft PR is a spike illustrating how to use `ThreadPoolTaskScheduler` to schedule tasks